### PR TITLE
ドメイン型の実装

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -369,10 +369,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
+name = "env_logger"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
 name = "event-listener"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
+name = "fake"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d68f517805463f3a896a9d29c1d6ff09d3579ded64a7201b4069f8f9c0d52fd"
+dependencies = [
+ "rand",
+]
 
 [[package]]
 name = "fnv"
@@ -985,6 +1004,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "quickcheck"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "588f6378e4dd99458b60ec275b4477add41ce4fa9f64dcba6f15adccb19b50d6"
+dependencies = [
+ "env_logger",
+ "log",
+ "rand",
+]
+
+[[package]]
+name = "quickcheck_macros"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b22a693222d716a9587786f37ac3f6b4faedb5b80c23914e7303ff5a1d8016e9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1973,8 +2014,11 @@ dependencies = [
  "chrono",
  "claims",
  "config",
+ "fake",
  "hyper",
  "mime",
+ "quickcheck",
+ "quickcheck_macros",
  "serde",
  "sqlx",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,6 +170,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "claims"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6995bbe186456c36307f8ea36be3eefe42f49d106896414e18efc4fb2f846b5"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "codespan-reporting"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1904,6 +1913,7 @@ version = "0.1.0"
 dependencies = [
  "axum",
  "chrono",
+ "claims",
  "config",
  "hyper",
  "mime",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,6 +14,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -596,6 +605,17 @@ dependencies = [
 
 [[package]]
 name = "idna"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
+dependencies = [
+ "matches",
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "idna"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
@@ -703,6 +723,12 @@ checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "matches"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
 name = "matchit"
@@ -1019,6 +1045,23 @@ dependencies = [
  "redox_syscall",
  "thiserror",
 ]
+
+[[package]]
+name = "regex"
+version = "1.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b1f693b24f6ac912f4893ef08244d70b6067480d2f1a46e950c9691e6749d1d"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "ring"
@@ -1601,7 +1644,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643"
 dependencies = [
  "form_urlencoded",
- "idna",
+ "idna 0.3.0",
  "percent-encoding",
 ]
 
@@ -1612,6 +1655,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55a3fef2a1e3b3a00ce878640918820d3c51081576ac657d23af9fc7928fdb"
 dependencies = [
  "getrandom",
+]
+
+[[package]]
+name = "validator"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32ad5bf234c7d3ad1042e5252b7eddb2c4669ee23f32c7dd0e9b7705f07ef591"
+dependencies = [
+ "idna 0.2.3",
+ "lazy_static",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "url",
 ]
 
 [[package]]
@@ -1923,4 +1981,5 @@ dependencies = [
  "tower",
  "unicode-segmentation",
  "uuid",
+ "validator",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1911,5 +1911,6 @@ dependencies = [
  "sqlx",
  "tokio",
  "tower",
+ "unicode-segmentation",
  "uuid",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ tokio = { version = "1.27.0", features = ["full"] }
 config = "0.13.3"
 uuid = { version = "1.3.1", features = ["v4"] }
 chrono = { version = "0.4.24", features = ["clock"] }
+unicode-segmentation = "1"
 
 [dependencies.sqlx]
 version = "^0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ config = "0.13.3"
 uuid = { version = "1.3.1", features = ["v4"] }
 chrono = { version = "0.4.24", features = ["clock"] }
 unicode-segmentation = "1"
+validator = "0.16"
 
 [dependencies.sqlx]
 version = "^0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,9 @@ uuid = { version = "1.3.1", features = ["v4"] }
 chrono = { version = "0.4.24", features = ["clock"] }
 unicode-segmentation = "1"
 validator = "0.16"
+fake = "2.5"
+quickcheck = "1"
+quickcheck_macros = "1"
 
 [dependencies.sqlx]
 version = "^0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ features = [
 ]
 
 [dev-dependencies]
+claims = "0.7"
 hyper = "0.14.26"
 mime = "0.3.17"
 tower = "0.4.13"

--- a/src/domain.rs
+++ b/src/domain.rs
@@ -22,10 +22,10 @@ impl SubscriberName {
             Self(s)
         }
     }
+}
 
-    pub fn inner_ref(&self) -> &str {
-        // 呼び出し元は不変共有参照を取得する
-        // 読み出し専用であるため、内部のデータを変更することができない
+impl AsRef<str> for SubscriberName {
+    fn as_ref(&self) -> &str {
         &self.0
     }
 }

--- a/src/domain.rs
+++ b/src/domain.rs
@@ -1,0 +1,31 @@
+use unicode_segmentation::UnicodeSegmentation;
+
+pub struct NewSubscriber {
+    pub email: String,
+    pub name: SubscriberName,
+}
+
+pub struct SubscriberName(String);
+
+impl SubscriberName {
+    pub fn parse(s: String) -> SubscriberName {
+        let is_empty_or_whitespace = s.trim().is_empty();
+
+        let is_too_long = s.graphemes(true).count() > 256;
+
+        let forbidden_characters = ['/', '(', ')', '"', '<', '>', '\\', '{', '}'];
+        let contains_forbidden_characters = s.chars().any(|g| forbidden_characters.contains(&g));
+
+        if is_empty_or_whitespace || is_too_long || contains_forbidden_characters {
+            panic!("{} is not a valid subscriber name", s);
+        } else {
+            Self(s)
+        }
+    }
+
+    pub fn inner_ref(&self) -> &str {
+        // 呼び出し元は不変共有参照を取得する
+        // 読み出し専用であるため、内部のデータを変更することができない
+        &self.0
+    }
+}

--- a/src/domain.rs
+++ b/src/domain.rs
@@ -5,6 +5,7 @@ pub struct NewSubscriber {
     pub name: SubscriberName,
 }
 
+#[derive(Debug)]
 pub struct SubscriberName(String);
 
 impl SubscriberName {
@@ -17,7 +18,7 @@ impl SubscriberName {
         let contains_forbidden_characters = s.chars().any(|g| forbidden_characters.contains(&g));
 
         if is_empty_or_whitespace || is_too_long || contains_forbidden_characters {
-            panic!("{} is not a valid subscriber name", s);
+            Err(format!("{} is not a valid subscriber name", s))
         } else {
             Ok(Self(s))
         }
@@ -27,5 +28,48 @@ impl SubscriberName {
 impl AsRef<str> for SubscriberName {
     fn as_ref(&self) -> &str {
         &self.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::domain::SubscriberName;
+    use claims::{assert_err, assert_ok};
+
+    #[test]
+    fn a_256_grapheme_long_name_is_valid() {
+        let name = "ё".repeat(256);
+        assert_ok!(SubscriberName::parse(name));
+    }
+
+    #[test]
+    fn a_name_longer_than_256_graphemes_is_rejected() {
+        let name = "a".repeat(257);
+        assert_err!(SubscriberName::parse(name));
+    }
+
+    #[test]
+    fn whitespace_only_names_are_rejected() {
+        let name = " ".to_string();
+        assert_err!(SubscriberName::parse(name));
+    }
+    #[test]
+    fn empty_string_is_rejected() {
+        let name = "".to_string();
+        assert_err!(SubscriberName::parse(name));
+    }
+
+    #[test]
+    fn names_containing_an_invalid_character_are_rejected() {
+        for name in &['/', '(', ')', '"', '<', '>', '\\', '{', '}'] {
+            let name = name.to_string();
+            assert_err!(SubscriberName::parse(name));
+        }
+    }
+
+    #[test]
+    fn a_valid_name_is_parsed_successfully() {
+        let name = "Ursula Le Guin".to_string();
+        assert_ok!(SubscriberName::parse(name));
     }
 }

--- a/src/domain.rs
+++ b/src/domain.rs
@@ -8,7 +8,7 @@ pub struct NewSubscriber {
 pub struct SubscriberName(String);
 
 impl SubscriberName {
-    pub fn parse(s: String) -> SubscriberName {
+    pub fn parse(s: String) -> Result<SubscriberName, String> {
         let is_empty_or_whitespace = s.trim().is_empty();
 
         let is_too_long = s.graphemes(true).count() > 256;
@@ -19,7 +19,7 @@ impl SubscriberName {
         if is_empty_or_whitespace || is_too_long || contains_forbidden_characters {
             panic!("{} is not a valid subscriber name", s);
         } else {
-            Self(s)
+            Ok(Self(s))
         }
     }
 }

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -3,4 +3,5 @@ mod subscriber_email;
 mod subscriber_name;
 
 pub use new_subscriber::NewSubscriber;
+pub use subscriber_email::SubscriberEmail;
 pub use subscriber_name::SubscriberName;

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -1,0 +1,6 @@
+mod new_subscriber;
+mod subscriber_email;
+mod subscriber_name;
+
+pub use new_subscriber::NewSubscriber;
+pub use subscriber_name::SubscriberName;

--- a/src/domain/new_subscriber.rs
+++ b/src/domain/new_subscriber.rs
@@ -1,0 +1,6 @@
+use crate::domain::subscriber_name::SubscriberName;
+
+pub struct NewSubscriber {
+    pub email: String,
+    pub name: SubscriberName,
+}

--- a/src/domain/new_subscriber.rs
+++ b/src/domain/new_subscriber.rs
@@ -1,6 +1,7 @@
-use crate::domain::subscriber_name::SubscriberName;
+use super::SubscriberEmail;
+use super::SubscriberName;
 
 pub struct NewSubscriber {
-    pub email: String,
+    pub email: SubscriberEmail,
     pub name: SubscriberName,
 }

--- a/src/domain/subscriber_email.rs
+++ b/src/domain/subscriber_email.rs
@@ -1,0 +1,44 @@
+use validator::validate_email;
+
+#[derive(Debug)]
+pub struct SubscriberEmail(String);
+
+impl SubscriberEmail {
+    pub fn parse(s: String) -> Result<SubscriberEmail, String> {
+        if validate_email(&s) {
+            Ok(Self(s))
+        } else {
+            Err(format!("{} is not a valid subscriber email", s))
+        }
+    }
+}
+
+impl AsRef<str> for SubscriberEmail {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::domain::SubscriberEmail;
+    use claims::assert_err;
+
+    #[test]
+    fn empty_string_is_rejected() {
+        let email = "".to_string();
+        assert_err!(SubscriberEmail::parse(email));
+    }
+
+    #[test]
+    fn email_missing_at_symbol_is_rejected() {
+        let email = "shimopinoexample.com".to_string();
+        assert_err!(SubscriberEmail::parse(email));
+    }
+
+    #[test]
+    fn email_missing_subject_is_rejected() {
+        let email = "@example.com".to_string();
+        assert_err!(SubscriberEmail::parse(email));
+    }
+}

--- a/src/domain/subscriber_email.rs
+++ b/src/domain/subscriber_email.rs
@@ -22,7 +22,18 @@ impl AsRef<str> for SubscriberEmail {
 #[cfg(test)]
 mod tests {
     use crate::domain::SubscriberEmail;
-    use claims::assert_err;
+    use claims::{assert_err, assert_ok};
+    use fake::{faker::internet::en::SafeEmail, Fake};
+
+    // #[derive(Debug, Clone)]
+    // struct ValidEmailFixture(pub String);
+
+    // impl quickcheck::Arbitrary for ValidEmailFixture {
+    //     fn arbitrary<G: quickcheck::Gen>(g: &mut G) -> Self {
+    //         let email = SafeEmail().fake_with_rng(g);
+    //         Self(email)
+    //     }
+    // }
 
     #[test]
     fn empty_string_is_rejected() {
@@ -41,4 +52,15 @@ mod tests {
         let email = "@example.com".to_string();
         assert_err!(SubscriberEmail::parse(email));
     }
+
+    #[test]
+    fn valid_emails_are_parsed_successfully() {
+        let email = SafeEmail().fake();
+        assert_ok!(SubscriberEmail::parse(email));
+    }
+
+    // #[quickcheck_macros::quickcheck]
+    // fn valid_emails_are_parsed_successfully(valid_email: String) -> bool {
+    //     SubscriberEmail::parse(valid_email).is_ok()
+    // }
 }

--- a/src/domain/subscriber_name.rs
+++ b/src/domain/subscriber_name.rs
@@ -1,10 +1,5 @@
 use unicode_segmentation::UnicodeSegmentation;
 
-pub struct NewSubscriber {
-    pub email: String,
-    pub name: SubscriberName,
-}
-
 #[derive(Debug)]
 pub struct SubscriberName(String);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod configuration;
+pub mod domain;
 pub mod routes;
 pub mod startup;

--- a/src/routes/subscriptions.rs
+++ b/src/routes/subscriptions.rs
@@ -55,8 +55,7 @@ pub async fn insert_subscriber(
         Utc::now()
     )
     .execute(pool)
-    .await
-    .map_err(|e| e)?;
+    .await?;
 
     Ok(())
 }

--- a/src/routes/subscriptions.rs
+++ b/src/routes/subscriptions.rs
@@ -2,6 +2,7 @@ use axum::{extract::State, http::StatusCode, response::IntoResponse, Form};
 use chrono::Utc;
 use serde::Deserialize;
 use sqlx::PgPool;
+use unicode_segmentation::UnicodeSegmentation;
 use uuid::Uuid;
 
 #[derive(Debug, Deserialize)]
@@ -14,7 +15,9 @@ pub async fn subscribe(
     State(pool): State<PgPool>,
     Form(input): Form<Subscribe>,
 ) -> impl IntoResponse {
-    println!("{}, {}", input.name, input.email);
+    if !is_valid_name(&input.name) {
+        return StatusCode::BAD_REQUEST;
+    }
 
     match sqlx::query!(
         r#"
@@ -35,4 +38,15 @@ pub async fn subscribe(
             StatusCode::INTERNAL_SERVER_ERROR
         }
     }
+}
+
+pub fn is_valid_name(s: &str) -> bool {
+    let is_empty_or_whitespace = s.trim().is_empty();
+
+    let is_too_long = s.graphemes(true).count() > 256;
+
+    let forbidden_characters = ['/', '(', ')', '"', '<', '>', '\\', '{', '}'];
+    let contains_forbidden_characters = s.chars().any(|g| forbidden_characters.contains(&g));
+
+    !(is_empty_or_whitespace || is_too_long || contains_forbidden_characters)
 }

--- a/src/routes/subscriptions.rs
+++ b/src/routes/subscriptions.rs
@@ -18,7 +18,7 @@ pub async fn subscribe(
 ) -> impl IntoResponse {
     let new_subscriber = NewSubscriber {
         email: input.email,
-        name: SubscriberName::parse(input.name),
+        name: SubscriberName::parse(input.name).expect("Name validation failed."),
     };
 
     match insert_subscriber(&pool, &new_subscriber).await {

--- a/src/routes/subscriptions.rs
+++ b/src/routes/subscriptions.rs
@@ -41,7 +41,7 @@ pub async fn insert_subscriber(
         "#,
         Uuid::new_v4(),
         new_subscriber.email,
-        new_subscriber.name.inner_ref(),
+        new_subscriber.name.as_ref(),
         Utc::now()
     )
     .execute(pool)

--- a/src/routes/subscriptions.rs
+++ b/src/routes/subscriptions.rs
@@ -12,17 +12,21 @@ pub struct Subscribe {
     email: String,
 }
 
-pub fn parse_subscriber(form: Subscribe) -> Result<NewSubscriber, String> {
-    let name = SubscriberName::parse(form.name)?;
-    let email = SubscriberEmail::parse(form.email)?;
-    Ok(NewSubscriber { email, name })
+impl TryFrom<Subscribe> for NewSubscriber {
+    type Error = String;
+
+    fn try_from(value: Subscribe) -> Result<Self, Self::Error> {
+        let name = SubscriberName::parse(value.name)?;
+        let email = SubscriberEmail::parse(value.email)?;
+        Ok(NewSubscriber { email, name })
+    }
 }
 
 pub async fn subscribe(
     State(pool): State<PgPool>,
     Form(input): Form<Subscribe>,
 ) -> impl IntoResponse {
-    let new_subscriber = match parse_subscriber(input) {
+    let new_subscriber = match input.try_into() {
         Ok(subscriber) => subscriber,
         Err(_) => return StatusCode::BAD_REQUEST,
     };

--- a/src/routes/subscriptions.rs
+++ b/src/routes/subscriptions.rs
@@ -16,9 +16,14 @@ pub async fn subscribe(
     State(pool): State<PgPool>,
     Form(input): Form<Subscribe>,
 ) -> impl IntoResponse {
+    let name = match SubscriberName::parse(input.name) {
+        Ok(name) => name,
+        Err(_) => return StatusCode::BAD_REQUEST,
+    };
+
     let new_subscriber = NewSubscriber {
         email: input.email,
-        name: SubscriberName::parse(input.name).expect("Name validation failed."),
+        name,
     };
 
     match insert_subscriber(&pool, &new_subscriber).await {

--- a/tests/subscription.rs
+++ b/tests/subscription.rs
@@ -94,7 +94,7 @@ async fn subscribe_returns_200_when_fields_are_present_but_empty() {
         ("name=shimopino&email=not-an-email"),
     ];
 
-    for (body) in test_cases {
+    for body in test_cases {
         let request = Request::builder()
             .method(http::Method::POST)
             .uri("/subscriptions")
@@ -115,5 +115,10 @@ async fn subscribe_returns_200_when_fields_are_present_but_empty() {
             .expect("Failed to execute request");
 
         assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+        let bytes = hyper::body::to_bytes(response.into_body()).await.unwrap();
+        let body = std::str::from_utf8(bytes.as_ref());
+
+        assert_eq!(body, Ok(""));
     }
 }

--- a/tests/subscription.rs
+++ b/tests/subscription.rs
@@ -83,3 +83,37 @@ async fn subscribe_returns_400_when_invalid_body() {
         assert_eq!(body, Ok(error_message));
     }
 }
+
+#[tokio::test]
+async fn subscribe_returns_200_when_fields_are_present_but_empty() {
+    let mut test_app = setup_app().await;
+
+    let test_cases = vec![
+        ("name=&email=shimopino@example.com"),
+        ("name=shimopino&email="),
+        ("name=shimopino&email=not-an-email"),
+    ];
+
+    for (body) in test_cases {
+        let request = Request::builder()
+            .method(http::Method::POST)
+            .uri("/subscriptions")
+            .header(
+                http::header::CONTENT_TYPE,
+                mime::APPLICATION_WWW_FORM_URLENCODED.as_ref(),
+            )
+            .body(Body::from(body))
+            .unwrap();
+
+        let response = test_app
+            .app
+            .ready()
+            .await
+            .unwrap()
+            .call(request)
+            .await
+            .expect("Failed to execute request");
+
+        assert_eq!(response.status(), StatusCode::CREATED);
+    }
+}

--- a/tests/subscription.rs
+++ b/tests/subscription.rs
@@ -114,6 +114,6 @@ async fn subscribe_returns_200_when_fields_are_present_but_empty() {
             .await
             .expect("Failed to execute request");
 
-        assert_eq!(response.status(), StatusCode::CREATED);
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     }
 }


### PR DESCRIPTION
- test: 無効な入力に対する挙動確認を追加
- test: 期待値を不正な値に変更
- feat: 名前の検証処理を追加
- feat: Subscriberの名前を表現するための型を定義
- feat: AsRefの実装を追加
- feat: 正常系をResultに変換
- feat: 異常系をErrで表現
- feat: 早期returnでIntoResponseに変換
- feat: ドメイン周りの関数と型をディレクトリ分割
- feat: Emailに関するドメイン関数を追加
- feat: Emailのテストを追加
- feat: Emailに関しても失敗時にBAD Requestを返却する形式に変更
- refactor: ドメイン型への変換とエラーハンドリングを分離
- refactor: TryFrom型の実装により、型変換であることを明示的に表現
