### PR TITLE
ニュース登録機能を追加

### DIFF
--- a/sample/request.http
+++ b/sample/request.http
@@ -10,3 +10,15 @@ name=shimopino
 
 ### Emailのトークンを検証する
 GET http://127.0.0.1:8080/subscriptions/confirm?subscription_token=mytoken
+
+### 新しいニュースを登録する
+POST http://127.0.0.1:8080/newsletters
+Content-Type: application/json
+
+{
+    "title": "Newsletter title",
+    "content": {
+        "text": "Newsletter body as plain text",
+        "html": "<p>Newsletter body as HTML</p>"
+    }
+}

--- a/sqlx-data.json
+++ b/sqlx-data.json
@@ -32,6 +32,24 @@
     },
     "query": "\n        UPDATE subscriptions SET status = 'confirmed' WHERE id = $1\n        "
   },
+  "aa0445c107513863945f43341831ed03e685a19e5e1f2db7b8f9dee37643bd80": {
+    "describe": {
+      "columns": [
+        {
+          "name": "email",
+          "ordinal": 0,
+          "type_info": "Text"
+        }
+      ],
+      "nullable": [
+        false
+      ],
+      "parameters": {
+        "Left": []
+      }
+    },
+    "query": "\n        SELECT email FROM subscriptions WHERE status = 'confirmed'\n        "
+  },
   "e6822c9e162eabc20338cc27d51a8e80578803ec1589c234d93c3919d14a96a6": {
     "describe": {
       "columns": [],

--- a/src/domain/subscriber_email.rs
+++ b/src/domain/subscriber_email.rs
@@ -19,6 +19,12 @@ impl AsRef<str> for SubscriberEmail {
     }
 }
 
+impl std::fmt::Display for SubscriberEmail {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::domain::SubscriberEmail;

--- a/src/email_client.rs
+++ b/src/email_client.rs
@@ -31,7 +31,7 @@ impl EmailClient {
 
     pub async fn send_email(
         &self,
-        recipient: SubscriberEmail,
+        recipient: &SubscriberEmail,
         subject: &str,
         html_content: &str,
         text_content: &str,
@@ -145,7 +145,7 @@ mod tests {
 
         // Act
         let _ = email_client
-            .send_email(email(), &subject(), &content(), &content())
+            .send_email(&email(), &subject(), &content(), &content())
             .await;
 
         // Assert
@@ -168,7 +168,7 @@ mod tests {
 
         // Act
         let outcome = email_client
-            .send_email(email(), &subject(), &content(), &content())
+            .send_email(&email(), &subject(), &content(), &content())
             .await;
 
         // Assert
@@ -190,7 +190,7 @@ mod tests {
 
         // Act
         let outcome = email_client
-            .send_email(email(), &subject(), &content(), &content())
+            .send_email(&email(), &subject(), &content(), &content())
             .await;
 
         // Assert
@@ -213,7 +213,7 @@ mod tests {
 
         // Act
         let outcome = email_client
-            .send_email(email(), &subject(), &content(), &content())
+            .send_email(&email(), &subject(), &content(), &content())
             .await;
 
         // Assert

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -1,7 +1,9 @@
 mod health_check;
+mod newsletters;
 mod subscriptions;
 mod subscriptions_confirm;
 
 pub use health_check::*;
+pub use newsletters::*;
 pub use subscriptions::*;
 pub use subscriptions_confirm::*;

--- a/src/routes/newsletters.rs
+++ b/src/routes/newsletters.rs
@@ -1,6 +1,9 @@
-use axum::{response::IntoResponse, Json};
+use axum::{extract::State, response::IntoResponse, Json};
 use hyper::StatusCode;
 use serde::Deserialize;
+use sqlx::PgPool;
+
+use crate::{error::error_chain_fmt, startup::AppState};
 
 #[derive(Debug, Deserialize)]
 pub struct BodyData {
@@ -14,6 +17,56 @@ pub struct Content {
     text: String,
 }
 
-pub async fn publish_subscriber(Json(body): Json<BodyData>) -> impl IntoResponse {
-    StatusCode::OK
+#[derive(thiserror::Error)]
+pub enum PublishError {
+    #[error(transparent)]
+    UnexpectedError(#[from] anyhow::Error),
+}
+
+impl std::fmt::Debug for PublishError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        error_chain_fmt(self, f)
+    }
+}
+
+impl IntoResponse for PublishError {
+    fn into_response(self) -> axum::response::Response {
+        let status_code = match self {
+            PublishError::UnexpectedError(_) => StatusCode::INTERNAL_SERVER_ERROR,
+        };
+
+        status_code.into_response()
+    }
+}
+
+pub async fn publish_subscriber(
+    State(state): State<AppState>,
+    Json(body): Json<BodyData>,
+) -> Result<impl IntoResponse, PublishError> {
+    let _subscribers = get_confirmed_subscribers(&state.db_state.db_pool).await?;
+
+    Ok(StatusCode::OK)
+}
+
+struct ConfirmedSubscriber {
+    email: String,
+}
+
+#[tracing::instrument(name = "Get confirmed subscribers", skip(pool))]
+async fn get_confirmed_subscribers(
+    pool: &PgPool,
+) -> Result<Vec<ConfirmedSubscriber>, anyhow::Error> {
+    // クエリ内の列の名前が構造体のフィールドと同じであることが期待される
+    // 構造体リテラルを使用して行をマッピングする（順序は同じでなくても良い）
+    // 列がNULLの可能性がある場合は Option<_> でラップする必要がある
+    let rows = sqlx::query_as!(
+        ConfirmedSubscriber,
+        r#"
+        SELECT email
+        FROM subscriptions
+        WHERE status = 'confirmed' "#,
+    )
+    .fetch_all(pool)
+    .await?;
+    Ok(rows)
 }

--- a/src/routes/newsletters.rs
+++ b/src/routes/newsletters.rs
@@ -1,6 +1,19 @@
-use axum::response::IntoResponse;
+use axum::{response::IntoResponse, Json};
 use hyper::StatusCode;
+use serde::Deserialize;
 
-pub async fn publish_subscriber() -> impl IntoResponse {
+#[derive(Debug, Deserialize)]
+pub struct BodyData {
+    title: String,
+    content: Content,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Content {
+    html: String,
+    text: String,
+}
+
+pub async fn publish_subscriber(Json(body): Json<BodyData>) -> impl IntoResponse {
     StatusCode::OK
 }

--- a/src/routes/newsletters.rs
+++ b/src/routes/newsletters.rs
@@ -47,16 +47,30 @@ pub async fn publish_subscriber(
     let subscribers = get_confirmed_subscribers(&state.db_state.db_pool).await?;
 
     for subscriber in subscribers {
-        state
-            .email_client
-            .send_email(
-                &subscriber.email,
-                &body.title,
-                &body.content.html,
-                &body.content.text,
-            )
-            .await
-            .with_context(|| format!("Failed to send newsletter issue to {}", subscriber.email))?;
+        match subscriber {
+            Ok(subscriber) => {
+                state
+                    .email_client
+                    .send_email(
+                        &subscriber.email,
+                        &body.title,
+                        &body.content.html,
+                        &body.content.text,
+                    )
+                    .await
+                    .with_context(|| {
+                        format!("Failed to send newsletter issue to {}", subscriber.email)
+                    })?;
+            }
+            Err(error) => {
+                tracing::warn!(
+                    // error chainを構造化ログとして記録する
+                    error.cause_chain = ?error,
+                    "Skipping a confirmed subscriber. \
+                     Their stored contact details are invalid",
+                )
+            }
+        }
     }
 
     Ok(StatusCode::OK)
@@ -69,7 +83,7 @@ struct ConfirmedSubscriber {
 #[tracing::instrument(name = "Get confirmed subscribers", skip(pool))]
 async fn get_confirmed_subscribers(
     pool: &PgPool,
-) -> Result<Vec<ConfirmedSubscriber>, anyhow::Error> {
+) -> Result<Vec<Result<ConfirmedSubscriber, anyhow::Error>>, anyhow::Error> {
     struct Row {
         email: String,
     }
@@ -89,15 +103,9 @@ async fn get_confirmed_subscribers(
 
     let confirmed_subscribers = rows
         .into_iter()
-        .filter_map(|r| match SubscriberEmail::parse(r.email) {
-            Ok(email) => Some(ConfirmedSubscriber { email }),
-            Err(error) => {
-                tracing::warn!(
-                    "A confirmed subscriber is using an invalid email address.\n{}",
-                    error
-                );
-                None
-            }
+        .map(|r| match SubscriberEmail::parse(r.email) {
+            Ok(email) => Ok(ConfirmedSubscriber { email }),
+            Err(error) => Err(anyhow::anyhow!(error)),
         })
         .collect();
 

--- a/src/routes/newsletters.rs
+++ b/src/routes/newsletters.rs
@@ -1,0 +1,6 @@
+use axum::response::IntoResponse;
+use hyper::StatusCode;
+
+pub async fn publish_subscriber() -> impl IntoResponse {
+    StatusCode::OK
+}

--- a/src/routes/subscriptions.rs
+++ b/src/routes/subscriptions.rs
@@ -186,7 +186,7 @@ pub async fn send_confirmation_email(
     );
 
     email_client
-        .send_email(new_subscriber.email, "Welcome!", &html_body, &plain_body)
+        .send_email(&new_subscriber.email, "Welcome!", &html_body, &plain_body)
         .await
 }
 

--- a/src/startup.rs
+++ b/src/startup.rs
@@ -10,7 +10,7 @@ use sqlx::{postgres::PgPoolOptions, PgPool};
 use crate::{
     configuration::{DatabaseSettings, Settings},
     email_client::EmailClient,
-    routes::{confirm, health_check, subscribe},
+    routes::{confirm, health_check, publish_subscriber, subscribe},
 };
 
 #[derive(Clone)]
@@ -55,6 +55,7 @@ pub fn create_app(state: AppState) -> Router {
         .route("/health_check", get(health_check))
         .route("/subscriptions", post(subscribe))
         .route("/subscriptions/confirm", get(confirm))
+        .route("/newsletters", post(publish_subscriber))
         .with_state(state)
 }
 

--- a/tests/api/helpers.rs
+++ b/tests/api/helpers.rs
@@ -115,6 +115,26 @@ impl TestApp {
             .await
             .expect("Failed to execute request");
     }
+
+    pub async fn post_newsletters(&mut self, body: serde_json::Value) -> axum::http::StatusCode {
+        let request = Request::builder()
+            .method(http::Method::POST)
+            .uri("/newsletters")
+            .header(http::header::CONTENT_TYPE, mime::APPLICATION_JSON.as_ref())
+            .body(Body::from(serde_json::to_vec(&body).unwrap()))
+            .unwrap();
+
+        let response = self
+            .app
+            .ready()
+            .await
+            .unwrap()
+            .call(request)
+            .await
+            .expect("Failed to execute request");
+
+        response.status()
+    }
 }
 
 pub async fn setup_app() -> TestApp {

--- a/tests/api/main.rs
+++ b/tests/api/main.rs
@@ -3,5 +3,6 @@
 // テスト全体を1つのファイルとして実行することが可能となる
 mod health_check;
 mod helpers;
+mod newsletter;
 mod subscription;
 mod subscription_confirm;

--- a/tests/api/newsletter.rs
+++ b/tests/api/newsletter.rs
@@ -1,0 +1,68 @@
+use axum::{
+    body::Body,
+    http::{self, Request, StatusCode},
+};
+use serde_json::json;
+use tower::{Service, ServiceExt};
+use wiremock::{
+    matchers::{any, method, path},
+    Mock, ResponseTemplate,
+};
+
+use crate::helpers::{setup_app, TestApp};
+
+#[tokio::test]
+async fn newsletters_are_not_delivered_to_unconfirmed_subscribers() {
+    // Arrange
+    let mut app = setup_app().await;
+    create_unconfirmed_subscriber(&mut app).await;
+
+    Mock::given(any())
+        .respond_with(ResponseTemplate::new(200))
+        .expect(0)
+        .mount(&app.email_server)
+        .await;
+
+    // Act
+
+    let response = app
+        .app
+        .ready()
+        .await
+        .unwrap()
+        .call(
+            Request::builder()
+                .method(http::Method::POST)
+                .uri("/newsletters")
+                .header(http::header::CONTENT_TYPE, mime::APPLICATION_JSON.as_ref())
+                .body(Body::from(
+                    serde_json::to_vec(&json!({
+                        "title": "Newsletter title",
+                        "content": {
+                            "text": "Newsletter body as plain text",
+                            "html": "<p>Newsletter body as HTML</p>",
+                        }
+                    }))
+                    .unwrap(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .expect("Failed to execute request");
+
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+async fn create_unconfirmed_subscriber(app: &mut TestApp) {
+    let body = "name=shimopino&email=shimopino%40example.com";
+
+    let _mock_guard = Mock::given(path("/email"))
+        .and(method("POST"))
+        .respond_with(ResponseTemplate::new(200))
+        .named("Create unconfirmed subscriber")
+        .expect(1)
+        .mount_as_scoped(&app.email_server)
+        .await;
+
+    app.post_subscription(body.into()).await;
+}

--- a/tests/api/subscription_confirm.rs
+++ b/tests/api/subscription_confirm.rs
@@ -1,15 +1,12 @@
-use std::collections::HashMap;
-
 use axum::{
     body::Body,
     http::{self, Request, StatusCode},
 };
-use reqwest::Url;
 use tower::ServiceExt;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, ResponseTemplate};
 
-use crate::helpers::setup_app;
+use crate::helpers::{extract_query_params, setup_app};
 
 #[tokio::test]
 async fn confrmations_without_token_are_rejected_with_a_400() {
@@ -138,10 +135,4 @@ async fn clicking_on_the_confirmation_link_confirms_a_subscriber() {
     assert_eq!(saved.email, "shimopino@example.com");
     assert_eq!(saved.name, "shimopino");
     assert_eq!(saved.status, "confirmed");
-}
-
-fn extract_query_params(url: &Url) -> HashMap<String, String> {
-    url.query_pairs()
-        .map(|(key, value)| (key.to_string(), value.to_string()))
-        .collect()
 }


### PR DESCRIPTION
- test: 失敗するテストを追加
- feat: PASSするようにエンドポイントのみ追加
- test: 確認済みユーザーにニュースレターをメール送信することを確認する、失敗するテストを追加
- feat: エンドポイントがJSON形式のリクエストを受け付けるように修正
- test: 不正なリクエストボディ形式の検証テストを追加
- refactor: テスト側で重複しているコードを削除
- feat: ニュースの登録をResult型に変更
- feat: 確認済みユーザーに対してメールを送信する機能を追加
- feat: エラーハンドリングを行う箇所の責任を分割
- refactor: 構造体に変換せず、そのままのクエリ結果から変換するようにする
- chore: sqlx-dataを最新化
