### PR TITLE
APIを保護する

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2695,6 +2695,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "axum",
+ "base64 0.21.0",
  "chrono",
  "claims",
  "config",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,6 +50,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7de8ce5e0f9f8d88245311066a578d72b7af3e7088f32783804676302df237e4"
 
 [[package]]
+name = "argon2"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95c2fcf79ad1932ac6269a738109997a83c227c09b75842ae564dc8ede6a861c"
+dependencies = [
+ "base64ct",
+ "blake2",
+ "password-hash",
+]
+
+[[package]]
 name = "assert-json-diff"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -158,10 +169,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
 
 [[package]]
+name = "base64ct"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "block-buffer"
@@ -1260,6 +1286,17 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]
@@ -2713,6 +2750,7 @@ name = "zero2prod"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "argon2",
  "axum",
  "base64 0.21.0",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1008,6 +1008,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "keccak"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3afef3b6eff9ce9d8ff9b3601125eec7f0c8cbac7abd14f355d053fa56c98768"
+dependencies = [
+ "cpufeatures",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1764,6 +1773,16 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "sha3"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54c2bb1a323307527314a36bfb73f24febb08ce2b8a554bf4ffd6f51ad15198c"
+dependencies = [
+ "digest",
+ "keccak",
 ]
 
 [[package]]
@@ -2714,6 +2733,7 @@ dependencies = [
  "serde",
  "serde-aux",
  "serde_json",
+ "sha3",
  "sqlx",
  "thiserror",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ hyper = "0.14"
 rand = "0.8"
 thiserror = "1.0"
 anyhow = "1.0"
+base64 = "0.21"
 
 [dependencies.sqlx]
 version = "^0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ thiserror = "1.0"
 anyhow = "1.0"
 base64 = "0.21"
 sha3 = "0.10"
+argon2 = { version = "0.5", features = ["std"] }
 
 [dependencies.sqlx]
 version = "^0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ rand = "0.8"
 thiserror = "1.0"
 anyhow = "1.0"
 base64 = "0.21"
+sha3 = "0.10"
 
 [dependencies.sqlx]
 version = "^0.6"

--- a/migrations/20230503092825_create_users_table.sql
+++ b/migrations/20230503092825_create_users_table.sql
@@ -1,0 +1,6 @@
+-- Add migration script here
+CREATE TABLE users(
+    user_id uuid PRIMARY KEY,
+    username TEXT NOT NULL UNIQUE,
+    password TEXT NOT NULL
+);

--- a/migrations/20230503120801_rename_password_column.sql
+++ b/migrations/20230503120801_rename_password_column.sql
@@ -1,0 +1,2 @@
+-- Add migration script here
+ALTER TABLE users RENAME password TO password_hash;

--- a/migrations/20230503141607_add_salt_to_users.sql
+++ b/migrations/20230503141607_add_salt_to_users.sql
@@ -1,0 +1,2 @@
+-- Add migration script here
+ALTER TABLE users ADD COLUMN salt TEXT NOT NULL;

--- a/migrations/20230503145845_remove_salt_from_users.sql
+++ b/migrations/20230503145845_remove_salt_from_users.sql
@@ -1,0 +1,2 @@
+-- Add migration script here
+ALTER TABLE users DROP COLUMN salt;

--- a/sqlx-data.json
+++ b/sqlx-data.json
@@ -50,6 +50,27 @@
     },
     "query": "\n        SELECT email FROM subscriptions WHERE status = 'confirmed'\n        "
   },
+  "e353ac6e0fb68e50fe7bae5a6220759db689b9f96c6f639a97912020988b79c3": {
+    "describe": {
+      "columns": [
+        {
+          "name": "user_id",
+          "ordinal": 0,
+          "type_info": "Uuid"
+        }
+      ],
+      "nullable": [
+        false
+      ],
+      "parameters": {
+        "Left": [
+          "Text",
+          "Text"
+        ]
+      }
+    },
+    "query": "\n        SELECT user_id\n        FROM users\n        WHERE username = $1 AND password = $2 "
+  },
   "e6822c9e162eabc20338cc27d51a8e80578803ec1589c234d93c3919d14a96a6": {
     "describe": {
       "columns": [],

--- a/sqlx-data.json
+++ b/sqlx-data.json
@@ -1,5 +1,26 @@
 {
   "db": "PostgreSQL",
+  "03f7765c6a0083cf65ae554a9c6147b4987474a790218a079c9925daac57274b": {
+    "describe": {
+      "columns": [
+        {
+          "name": "user_id",
+          "ordinal": 0,
+          "type_info": "Uuid"
+        }
+      ],
+      "nullable": [
+        false
+      ],
+      "parameters": {
+        "Left": [
+          "Text",
+          "Text"
+        ]
+      }
+    },
+    "query": "\n        SELECT user_id\n        FROM users\n        WHERE username = $1 AND password_hash = $2 "
+  },
   "39a76ca87097dab85c9d35ea5e98720b3c2c44c87222a4d5a4f4a6cbbdecca9e": {
     "describe": {
       "columns": [
@@ -49,27 +70,6 @@
       }
     },
     "query": "\n        SELECT email FROM subscriptions WHERE status = 'confirmed'\n        "
-  },
-  "e353ac6e0fb68e50fe7bae5a6220759db689b9f96c6f639a97912020988b79c3": {
-    "describe": {
-      "columns": [
-        {
-          "name": "user_id",
-          "ordinal": 0,
-          "type_info": "Uuid"
-        }
-      ],
-      "nullable": [
-        false
-      ],
-      "parameters": {
-        "Left": [
-          "Text",
-          "Text"
-        ]
-      }
-    },
-    "query": "\n        SELECT user_id\n        FROM users\n        WHERE username = $1 AND password = $2 "
   },
   "e6822c9e162eabc20338cc27d51a8e80578803ec1589c234d93c3919d14a96a6": {
     "describe": {

--- a/sqlx-data.json
+++ b/sqlx-data.json
@@ -1,26 +1,5 @@
 {
   "db": "PostgreSQL",
-  "03f7765c6a0083cf65ae554a9c6147b4987474a790218a079c9925daac57274b": {
-    "describe": {
-      "columns": [
-        {
-          "name": "user_id",
-          "ordinal": 0,
-          "type_info": "Uuid"
-        }
-      ],
-      "nullable": [
-        false
-      ],
-      "parameters": {
-        "Left": [
-          "Text",
-          "Text"
-        ]
-      }
-    },
-    "query": "\n        SELECT user_id\n        FROM users\n        WHERE username = $1 AND password_hash = $2 "
-  },
   "39a76ca87097dab85c9d35ea5e98720b3c2c44c87222a4d5a4f4a6cbbdecca9e": {
     "describe": {
       "columns": [
@@ -70,6 +49,32 @@
       }
     },
     "query": "\n        SELECT email FROM subscriptions WHERE status = 'confirmed'\n        "
+  },
+  "acf1b96c82ddf18db02e71a0e297c822b46f10add52c54649cf599b883165e58": {
+    "describe": {
+      "columns": [
+        {
+          "name": "user_id",
+          "ordinal": 0,
+          "type_info": "Uuid"
+        },
+        {
+          "name": "password_hash",
+          "ordinal": 1,
+          "type_info": "Text"
+        }
+      ],
+      "nullable": [
+        false,
+        false
+      ],
+      "parameters": {
+        "Left": [
+          "Text"
+        ]
+      }
+    },
+    "query": "\n        SELECT user_id, password_hash\n        FROM users\n        WHERE username = $1\n        "
   },
   "e6822c9e162eabc20338cc27d51a8e80578803ec1589c234d93c3919d14a96a6": {
     "describe": {

--- a/src/routes/newsletters.rs
+++ b/src/routes/newsletters.rs
@@ -51,7 +51,7 @@ pub async fn publish_subscriber(
     State(state): State<AppState>,
     Json(body): Json<BodyData>,
 ) -> Result<impl IntoResponse, PublishError> {
-    let _credentials = basic_authentication(&headers).map_err(PublishError::AuthError);
+    let _credentials = basic_authentication(&headers).map_err(PublishError::AuthError)?;
 
     let subscribers = get_confirmed_subscribers(&state.db_state.db_pool).await?;
 

--- a/src/routes/newsletters.rs
+++ b/src/routes/newsletters.rs
@@ -188,21 +188,35 @@ async fn validate_credentials(
         .map_err(PublishError::UnexpectedError)?
         .ok_or_else(|| PublishError::AuthError(anyhow::anyhow!("Unknown username.")))?;
 
+    tokio::task::spawn_blocking(move || {
+        verify_password_hash(expected_password_hash, credentials.password)
+    })
+    .await
+    .context("Failed to spawn blocking task")
+    .map_err(PublishError::UnexpectedError)??;
+
+    Ok(user_id)
+}
+
+#[tracing::instrument(
+    name = "Verify password hash",
+    skip(expected_password_hash, password_candidate)
+)]
+fn verify_password_hash(
+    expected_password_hash: Secret<String>,
+    password_candidate: Secret<String>,
+) -> Result<(), PublishError> {
     let expected_password_hash = PasswordHash::new(expected_password_hash.expose_secret())
         .context("Failed to parse hash in PHC string format.")
         .map_err(PublishError::UnexpectedError)?;
 
-    tracing::info_span!("Verify password hash")
-        .in_scope(|| {
-            Argon2::default().verify_password(
-                credentials.password.expose_secret().as_bytes(),
-                &expected_password_hash,
-            )
-        })
+    Argon2::default()
+        .verify_password(
+            password_candidate.expose_secret().as_bytes(),
+            &expected_password_hash,
+        )
         .context("Invalid password.")
-        .map_err(PublishError::AuthError)?;
-
-    Ok(user_id)
+        .map_err(PublishError::AuthError)
 }
 
 #[tracing::instrument(name = "Get stored credentials", skip(username, pool))]

--- a/src/routes/newsletters.rs
+++ b/src/routes/newsletters.rs
@@ -45,6 +45,7 @@ impl IntoResponse for PublishError {
     }
 }
 
+#[tracing::instrument(name = "Publish subcriber handler", skip(state, headers))]
 pub async fn publish_subscriber(
     headers: HeaderMap,
     State(state): State<AppState>,
@@ -124,7 +125,7 @@ struct Credentials {
 fn basic_authentication(headers: &HeaderMap) -> Result<Credentials, anyhow::Error> {
     let header_value = headers
         .get("Authorization")
-        .context("The 'Authrization' header was missing")?
+        .context("The 'Authorization' header was missing")?
         .to_str()
         .context("The 'Authorization' header was not a valid UTF8 string.")?;
 

--- a/src/routes/newsletters.rs
+++ b/src/routes/newsletters.rs
@@ -1,6 +1,8 @@
 use anyhow::Context;
 use axum::{extract::State, response::IntoResponse, Json};
-use hyper::StatusCode;
+use base64::Engine;
+use hyper::{HeaderMap, StatusCode};
+use secrecy::Secret;
 use serde::Deserialize;
 use sqlx::PgPool;
 
@@ -20,6 +22,8 @@ pub struct Content {
 
 #[derive(thiserror::Error)]
 pub enum PublishError {
+    #[error("Authentication failed")]
+    AuthError(#[source] anyhow::Error),
     #[error(transparent)]
     UnexpectedError(#[from] anyhow::Error),
 }
@@ -34,6 +38,7 @@ impl IntoResponse for PublishError {
     fn into_response(self) -> axum::response::Response {
         let status_code = match self {
             PublishError::UnexpectedError(_) => StatusCode::INTERNAL_SERVER_ERROR,
+            PublishError::AuthError(_) => StatusCode::UNAUTHORIZED,
         };
 
         status_code.into_response()
@@ -41,9 +46,12 @@ impl IntoResponse for PublishError {
 }
 
 pub async fn publish_subscriber(
+    headers: HeaderMap,
     State(state): State<AppState>,
     Json(body): Json<BodyData>,
 ) -> Result<impl IntoResponse, PublishError> {
+    let _credentials = basic_authentication(&headers).map_err(PublishError::AuthError);
+
     let subscribers = get_confirmed_subscribers(&state.db_state.db_pool).await?;
 
     for subscriber in subscribers {
@@ -105,4 +113,45 @@ async fn get_confirmed_subscribers(
     .collect();
 
     Ok(confirmed_subscribers)
+}
+
+struct Credentials {
+    username: String,
+    password: Secret<String>,
+}
+
+#[tracing::instrument(name = "extract username & password from Authorization")]
+fn basic_authentication(headers: &HeaderMap) -> Result<Credentials, anyhow::Error> {
+    let header_value = headers
+        .get("Authorization")
+        .context("The 'Authrization' header was missing")?
+        .to_str()
+        .context("The 'Authorization' header was not a valid UTF8 string.")?;
+
+    let base64encoded_segment = header_value
+        .strip_prefix("Basic ")
+        .context("The authorization scheme was not 'Basic'")?;
+
+    let decoded_bytes = base64::engine::general_purpose::STANDARD
+        .decode(base64encoded_segment)
+        .context("Failed to base64-encoded 'Basic' credentials")?;
+
+    let decoded_credentials = String::from_utf8(decoded_bytes)
+        .context("The decoded credentials string is not valid UTF8.")?;
+
+    // 仕様に基づいてユーザー名とパスワードを分離
+    let mut credentials = decoded_credentials.splitn(2, ':');
+    let username = credentials
+        .next()
+        .ok_or_else(|| anyhow::anyhow!("A username must be provided in 'Basic' auth"))?
+        .to_string();
+    let password = credentials
+        .next()
+        .ok_or_else(|| anyhow::anyhow!("A password must be provided in 'Basic' auth"))?
+        .to_string();
+
+    Ok(Credentials {
+        username,
+        password: Secret::new(password),
+    })
 }

--- a/src/routes/newsletters.rs
+++ b/src/routes/newsletters.rs
@@ -186,10 +186,22 @@ async fn validate_credentials(
     credentials: Credentials,
     pool: &PgPool,
 ) -> Result<uuid::Uuid, PublishError> {
-    let (user_id, expected_password_hash) = get_stored_credentials(&credentials.username, pool)
-        .await
-        .map_err(PublishError::UnexpectedError)?
-        .ok_or_else(|| PublishError::AuthError(anyhow::anyhow!("Unknown username.")))?;
+    let mut user_id = None;
+    let mut expected_password_hash = Secret::new(
+        "$argon2id$v=19$m=15000,t=2,p=1$\
+        gZiV/M1gPc22ElAH/Jh1Hw$\
+        CWOrkoo7oJBQ/iyh7uJ0LO2aLEfrHwTWllSAxT0zRno"
+            .to_string(),
+    );
+
+    if let Some((stored_user_id, stored_password_hash)) =
+        get_stored_credentials(&credentials.username, pool)
+            .await
+            .map_err(PublishError::UnexpectedError)?
+    {
+        user_id = Some(stored_user_id);
+        expected_password_hash = stored_password_hash;
+    }
 
     spawn_blocking_with_tracing(move || {
         verify_password_hash(expected_password_hash, credentials.password)
@@ -198,7 +210,7 @@ async fn validate_credentials(
     .context("Failed to spawn blocking task")
     .map_err(PublishError::UnexpectedError)??;
 
-    Ok(user_id)
+    user_id.ok_or_else(|| PublishError::AuthError(anyhow::anyhow!("Unknown username.")))
 }
 
 #[tracing::instrument(

--- a/src/routes/newsletters.rs
+++ b/src/routes/newsletters.rs
@@ -7,7 +7,7 @@ use axum::{
 };
 use base64::Engine;
 use hyper::{header, HeaderMap, StatusCode};
-use secrecy::Secret;
+use secrecy::{ExposeSecret, Secret};
 use serde::Deserialize;
 use sqlx::PgPool;
 
@@ -57,13 +57,21 @@ impl IntoResponse for PublishError {
     }
 }
 
-#[tracing::instrument(name = "Publish subcriber handler", skip(state, headers))]
+#[tracing::instrument(
+    name = "Publish a newsletterissue",
+    skip(state, headers, body),
+    fields(username=tracing::field::Empty, user_id=tracing::field::Empty)
+)]
 pub async fn publish_subscriber(
     headers: HeaderMap,
     State(state): State<AppState>,
     Json(body): Json<BodyData>,
 ) -> Result<impl IntoResponse, PublishError> {
-    let _credentials = basic_authentication(&headers).map_err(PublishError::AuthError)?;
+    let credentials = basic_authentication(&headers).map_err(PublishError::AuthError)?;
+    tracing::Span::current().record("username", &tracing::field::display(&credentials.username));
+
+    let user_id = validate_credentials(credentials, &state.db_state.db_pool).await?;
+    tracing::Span::current().record("user_id", &tracing::field::display(&user_id));
 
     let subscribers = get_confirmed_subscribers(&state.db_state.db_pool).await?;
 
@@ -167,4 +175,27 @@ fn basic_authentication(headers: &HeaderMap) -> Result<Credentials, anyhow::Erro
         username,
         password: Secret::new(password),
     })
+}
+
+async fn validate_credentials(
+    credentials: Credentials,
+    pool: &PgPool,
+) -> Result<uuid::Uuid, PublishError> {
+    let user_id: Option<_> = sqlx::query!(
+        r#"
+        SELECT user_id
+        FROM users
+        WHERE username = $1 AND password = $2 "#,
+        credentials.username,
+        credentials.password.expose_secret()
+    )
+    .fetch_optional(pool)
+    .await
+    .context("Failed to perform a query to validate auth credentials.")
+    .map_err(PublishError::UnexpectedError)?;
+
+    user_id
+        .map(|row| row.user_id)
+        .ok_or_else(|| anyhow::anyhow!("Invalid username or password"))
+        .map_err(PublishError::UnexpectedError)
 }

--- a/src/routes/newsletters.rs
+++ b/src/routes/newsletters.rs
@@ -1,4 +1,5 @@
 use anyhow::Context;
+use argon2::{Argon2, PasswordHash, PasswordVerifier};
 use axum::{
     body::Body,
     extract::State,
@@ -9,7 +10,6 @@ use base64::Engine;
 use hyper::{header, HeaderMap, StatusCode};
 use secrecy::{ExposeSecret, Secret};
 use serde::Deserialize;
-use sha3::Digest;
 use sqlx::PgPool;
 
 use crate::{domain::SubscriberEmail, error::error_chain_fmt, startup::AppState};
@@ -182,26 +182,39 @@ async fn validate_credentials(
     credentials: Credentials,
     pool: &PgPool,
 ) -> Result<uuid::Uuid, PublishError> {
-    let password_hash = sha3::Sha3_256::digest(credentials.password.expose_secret().as_bytes());
-
-    // 小文字での16進数でのエンコーディング
-    let password_hash = format!("{:x}", password_hash);
-
-    let user_id: Option<_> = sqlx::query!(
+    let row: Option<_> = sqlx::query!(
         r#"
-        SELECT user_id
+        SELECT user_id, password_hash
         FROM users
-        WHERE username = $1 AND password_hash = $2 "#,
-        credentials.username,
-        password_hash
+        WHERE username = $1
+        "#,
+        credentials.username
     )
     .fetch_optional(pool)
     .await
-    .context("Failed to perform a query to validate auth credentials.")
+    .context("Failed to perform a query to retrieve stored credentials.")
     .map_err(PublishError::UnexpectedError)?;
 
-    user_id
-        .map(|row| row.user_id)
-        .ok_or_else(|| anyhow::anyhow!("Invalid username or password"))
-        .map_err(PublishError::UnexpectedError)
+    let (expected_password_hash, user_id) = match row {
+        Some(row) => (row.password_hash, row.user_id),
+        None => {
+            return Err(PublishError::AuthError(anyhow::anyhow!(
+                "Unknown username."
+            )))
+        }
+    };
+
+    let expected_password_hash = PasswordHash::new(&expected_password_hash)
+        .context("Failed to parse hash in PHC string format.")
+        .map_err(PublishError::UnexpectedError)?;
+
+    Argon2::default()
+        .verify_password(
+            credentials.password.expose_secret().as_bytes(),
+            &expected_password_hash,
+        )
+        .context("Invalid password.")
+        .map_err(PublishError::AuthError)?;
+
+    Ok(user_id)
 }

--- a/src/routes/newsletters.rs
+++ b/src/routes/newsletters.rs
@@ -178,43 +178,50 @@ fn basic_authentication(headers: &HeaderMap) -> Result<Credentials, anyhow::Erro
     })
 }
 
+#[tracing::instrument(name = "Validate credentials", skip(credentials, pool))]
 async fn validate_credentials(
     credentials: Credentials,
     pool: &PgPool,
 ) -> Result<uuid::Uuid, PublishError> {
-    let row: Option<_> = sqlx::query!(
+    let (user_id, expected_password_hash) = get_stored_credentials(&credentials.username, pool)
+        .await
+        .map_err(PublishError::UnexpectedError)?
+        .ok_or_else(|| PublishError::AuthError(anyhow::anyhow!("Unknown username.")))?;
+
+    let expected_password_hash = PasswordHash::new(expected_password_hash.expose_secret())
+        .context("Failed to parse hash in PHC string format.")
+        .map_err(PublishError::UnexpectedError)?;
+
+    tracing::info_span!("Verify password hash")
+        .in_scope(|| {
+            Argon2::default().verify_password(
+                credentials.password.expose_secret().as_bytes(),
+                &expected_password_hash,
+            )
+        })
+        .context("Invalid password.")
+        .map_err(PublishError::AuthError)?;
+
+    Ok(user_id)
+}
+
+#[tracing::instrument(name = "Get stored credentials", skip(username, pool))]
+async fn get_stored_credentials(
+    username: &str,
+    pool: &PgPool,
+) -> Result<Option<(uuid::Uuid, Secret<String>)>, anyhow::Error> {
+    let row = sqlx::query!(
         r#"
         SELECT user_id, password_hash
         FROM users
         WHERE username = $1
         "#,
-        credentials.username
+        username
     )
     .fetch_optional(pool)
     .await
-    .context("Failed to perform a query to retrieve stored credentials.")
-    .map_err(PublishError::UnexpectedError)?;
+    .context("Failed to perform a query to retrieve stored credentials.")?
+    .map(|row| (row.user_id, Secret::new(row.password_hash)));
 
-    let (expected_password_hash, user_id) = match row {
-        Some(row) => (row.password_hash, row.user_id),
-        None => {
-            return Err(PublishError::AuthError(anyhow::anyhow!(
-                "Unknown username."
-            )))
-        }
-    };
-
-    let expected_password_hash = PasswordHash::new(&expected_password_hash)
-        .context("Failed to parse hash in PHC string format.")
-        .map_err(PublishError::UnexpectedError)?;
-
-    Argon2::default()
-        .verify_password(
-            credentials.password.expose_secret().as_bytes(),
-            &expected_password_hash,
-        )
-        .context("Invalid password.")
-        .map_err(PublishError::AuthError)?;
-
-    Ok(user_id)
+    Ok(row)
 }

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -1,3 +1,4 @@
+use tokio::task::JoinHandle;
 use tracing::{subscriber::set_global_default, Subscriber};
 use tracing_bunyan_formatter::{BunyanFormattingLayer, JsonStorageLayer};
 use tracing_log::LogTracer;
@@ -33,4 +34,13 @@ pub fn init_subscriber(subscriber: impl Subscriber + Send + Sync) {
     // Logで出力されている内容をSubscriberに転送する
     LogTracer::init().expect("Failed to set logger");
     set_global_default(subscriber).expect("Failed to set subscriber");
+}
+
+pub fn spawn_blocking_with_tracing<F, R>(f: F) -> JoinHandle<R>
+where
+    F: FnOnce() -> R + Send + 'static,
+    R: Send + 'static,
+{
+    let current_span = tracing::Span::current();
+    tokio::task::spawn_blocking(move || current_span.in_scope(f))
 }

--- a/tests/api/helpers.rs
+++ b/tests/api/helpers.rs
@@ -5,6 +5,7 @@ use axum::{
     http::{self, Request},
     Router,
 };
+use hyper::HeaderMap;
 use once_cell::sync::Lazy;
 use reqwest::Url;
 use sqlx::{Connection, Executor, PgConnection, PgPool};
@@ -116,7 +117,10 @@ impl TestApp {
             .expect("Failed to execute request");
     }
 
-    pub async fn post_newsletters(&mut self, body: serde_json::Value) -> axum::http::StatusCode {
+    pub async fn post_newsletters(
+        &mut self,
+        body: serde_json::Value,
+    ) -> (axum::http::StatusCode, HeaderMap) {
         let request = Request::builder()
             .method(http::Method::POST)
             .uri("/newsletters")
@@ -133,7 +137,7 @@ impl TestApp {
             .await
             .expect("Failed to execute request");
 
-        response.status()
+        (response.status(), response.headers().to_owned())
     }
 }
 

--- a/tests/api/helpers.rs
+++ b/tests/api/helpers.rs
@@ -42,7 +42,7 @@ pub struct TestApp {
     pub app: Router,
     pub db_pool: PgPool,
     pub email_server: MockServer,
-    test_user: TestUser,
+    pub test_user: TestUser,
 }
 
 impl TestApp {

--- a/tests/api/helpers.rs
+++ b/tests/api/helpers.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use argon2::{password_hash::SaltString, Argon2, PasswordHasher};
 use axum::{
     body::Body,
     http::{self, HeaderValue, Request},
@@ -8,7 +9,6 @@ use axum::{
 use hyper::HeaderMap;
 use once_cell::sync::Lazy;
 use reqwest::Url;
-use sha3::Digest;
 use sqlx::{Connection, Executor, PgConnection, PgPool};
 use tower::{Service, ServiceExt};
 use uuid::Uuid;
@@ -166,8 +166,11 @@ impl TestUser {
     }
 
     async fn store(&self, pool: &PgPool) {
-        let password_hash = sha3::Sha3_256::digest(self.password.as_bytes());
-        let password_hash = format!("{:x}", password_hash);
+        let salt = SaltString::generate(&mut rand::thread_rng());
+        let password_hash = Argon2::default()
+            .hash_password(self.password.as_bytes(), &salt)
+            .unwrap()
+            .to_string();
 
         sqlx::query!(
             "INSERT INTO users (user_id, username, password_hash)

--- a/tests/api/helpers.rs
+++ b/tests/api/helpers.rs
@@ -167,10 +167,14 @@ impl TestUser {
 
     async fn store(&self, pool: &PgPool) {
         let salt = SaltString::generate(&mut rand::thread_rng());
-        let password_hash = Argon2::default()
-            .hash_password(self.password.as_bytes(), &salt)
-            .unwrap()
-            .to_string();
+        let password_hash = Argon2::new(
+            argon2::Algorithm::Argon2id,
+            argon2::Version::V0x13,
+            argon2::Params::new(15000, 2, 1, None).unwrap(),
+        )
+        .hash_password(self.password.as_bytes(), &salt)
+        .unwrap()
+        .to_string();
 
         sqlx::query!(
             "INSERT INTO users (user_id, username, password_hash)

--- a/tests/api/newsletter.rs
+++ b/tests/api/newsletter.rs
@@ -91,6 +91,25 @@ async fn newsletters_returns_400_for_invalid_data() {
     }
 }
 
+#[tokio::test]
+async fn requests_missing_authorization_are_rejected() {
+    // Arrange
+    let mut app = setup_app().await;
+
+    let response = app
+        .post_newsletters(serde_json::json!({
+            "title": "Newsletter title",
+            "content": {
+                "text": "Newsletter body as plain text",
+                "html": "<p>Newsletter body as HTML</p>"
+            }
+        }))
+        .await;
+
+    assert_eq!(response, StatusCode::UNAUTHORIZED);
+    // assert_eq!(r#"Basic realm="publish""#, headers.get("WWW-Authenticate"));
+}
+
 async fn create_unconfirmed_subscriber(app: &mut TestApp) -> ConfirmationLinks {
     let body = "name=shimopino&email=shimopino%40example.com";
 

--- a/tests/api/newsletter.rs
+++ b/tests/api/newsletter.rs
@@ -1,4 +1,4 @@
-use axum::http::{HeaderValue, StatusCode};
+use axum::http::StatusCode;
 use wiremock::{
     matchers::{any, method, path},
     Mock, ResponseTemplate,
@@ -27,7 +27,7 @@ async fn newsletters_are_not_delivered_to_unconfirmed_subscribers() {
         }
     });
 
-    let (status_code, _) = app.post_newsletters(newsletter_request_body).await;
+    let (status_code, _) = app.post_newsletters(newsletter_request_body, true).await;
 
     assert_eq!(status_code, StatusCode::OK);
 }
@@ -53,7 +53,7 @@ async fn newsletters_are_delivered_to_confirmed_subscribers() {
             "html": "<p>Newsletter body as HTML</p>",
         }
     });
-    let (status_code, _) = app.post_newsletters(newsletter_request_body).await;
+    let (status_code, _) = app.post_newsletters(newsletter_request_body, true).await;
 
     assert_eq!(status_code, StatusCode::OK);
 }
@@ -79,7 +79,7 @@ async fn newsletters_returns_400_for_invalid_data() {
     ];
 
     for (invalid_body, error_message) in test_cases {
-        let (status_code, _) = app.post_newsletters(invalid_body).await;
+        let (status_code, _) = app.post_newsletters(invalid_body, true).await;
 
         // Assert
         assert_eq!(
@@ -96,14 +96,19 @@ async fn requests_missing_authorization_are_rejected() {
     // Arrange
     let mut app = setup_app().await;
 
+    // Act
     let (status_code, headers) = app
-        .post_newsletters(serde_json::json!({
-            "title": "Newsletter title",
-            "content": {
-                "text": "Newsletter body as plain text",
-                "html": "<p>Newsletter body as HTML</p>"
-            }
-        }))
+        .post_newsletters(
+            serde_json::json!({
+                "title": "Newsletter title",
+                "content": {
+                    "text": "Newsletter body as plain text",
+                    "html": "<p>Newsletter body as HTML</p>"
+                }
+            }),
+            // ここだけメソッドを使用せずにそのままリクエストしてしまっても良さそう
+            false,
+        )
         .await;
 
     assert_eq!(status_code, StatusCode::UNAUTHORIZED);


### PR DESCRIPTION
- feat: ヘッダーの検証処理を追加
- chore: ログ出力を追加
- fix: エラー発生時に早期リターンするように修正
- test: Basic認証用のレスポンスヘッダーを返していることを確認するテストを追加
- test: 正常系のテストで Authorization ヘッダーを付与する形式に変更
